### PR TITLE
bug fix for Get-CrmEntityAttributeMetadata

### DIFF
--- a/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
+++ b/Microsoft.Xrm.Data.PowerShell/Microsoft.Xrm.Data.PowerShell.psm1
@@ -2577,7 +2577,7 @@ function Get-CrmEntityAttributeMetadata{
     try
     {
         $result = $conn.GetEntityAttributeMetadataForAttribute($EntityLogicalName, $FieldLogicalName)
-		if($result -ne $null)
+		if($result -eq $null)
         {
             return $conn.LastCrmException
         }


### PR DESCRIPTION
There is a bug due to a typo in Get-CrmEntityAttributeMetadata. The condition for the "if" statement should be "-eq" instead of "-ne" which makes this function always returns null.
